### PR TITLE
add schedule trigger to github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: ["main"]
 
+  # Runs also on a schedule to update "Last updated at" statements etc.
+  schedule:
+    - cron: "*/15 * * * *"
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
The page will keep reporting the last incident was "Last updated just now" because we only run the markup generation when we manually edit this repo, but I think the template expects to be run periodically to accurately update these time statements.

Note: I don't know if these changes do this correctly

